### PR TITLE
fix: sudo should not be needed for a reboot

### DIFF
--- a/src/done.rs
+++ b/src/done.rs
@@ -100,7 +100,7 @@ impl SimpleComponent for DoneModel {
     fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
         match message {
             Self::Input::Reboot => {
-                Command::new("pkexec").arg("/sbin/reboot").status().unwrap();
+                Command::new("/sbin/reboot").status().unwrap();
             },
             Self::Input::SwitchToErrorState => {
                 self.error_state = true;


### PR DESCRIPTION
For some reason a password prompt is needed to reboot which isn't necessary when running the command directly.